### PR TITLE
docs: Add unclaim/reclaim node guide

### DIFF
--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -164,6 +164,7 @@ https://github.com/netdata/netdata/edit/master/src/health/REFERENCE.md,Alert Con
 https://github.com/netdata/netdata/edit/master/src/web/api/health/README.md,Health API Calls,Published,Alerts & Notifications,
 ,,,,
 https://github.com/netdata/netdata/edit/master/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md,Netdata AI,Published,Netdata AI,
+https://github.com/netdata/netdata/edit/master/docs/ai-powered-alert-configuration/ai-powered-alert-configuration.md,AI-Powered Alert Configuration,Published,Netdata AI,
 https://github.com/netdata/netdata/edit/master/docs/ml-ai/ai-insights.md,Insights,Published,Netdata AI/Insights,
 https://github.com/netdata/netdata/edit/master/docs/netdata-ai/insights/infrastructure-summary.md,Infrastructure Summary,Published,Netdata AI/Insights,
 https://github.com/netdata/netdata/edit/master/docs/netdata-ai/insights/performance-optimization.md,Performance Optimization,Published,Netdata AI/Insights,

--- a/docs/.map/map.csv
+++ b/docs/.map/map.csv
@@ -91,6 +91,7 @@ https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/authentication
 https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/authentication-and-authorization/api-tokens.md,API Tokens,Published,Netdata Cloud/Authentication & Authorization,
 https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/view-plan-and-billing.md,Netdata Plans & Billing,Published,Netdata Cloud,
 https://github.com/netdata/netdata/edit/master/src/aclk/README.md,Agent-Cloud Link (ACLK),Published,Netdata Cloud,The Agent-Cloud link (ACLK) is the mechanism responsible for connecting a Netdata agent to Netdata Cloud.
+https://github.com/netdata/netdata/edit/master/docs/learn/unclaim-reclaim-node.md,Unclaim and Reclaim a Node,Published,Netdata Cloud,
 https://github.com/netdata/netdata/edit/master/docs/learn/remove-node.md,Remove Agent,Published,Netdata Cloud,
 https://github.com/netdata/netdata/edit/master/docs/delete/netdata/account.md,Account Deletion,Published,Netdata Cloud,
 ,,,,

--- a/docs/ai-powered-alert-configuration/ai-powered-alert-configuration.md
+++ b/docs/ai-powered-alert-configuration/ai-powered-alert-configuration.md
@@ -1,0 +1,89 @@
+# AI-Powered Alert Configuration
+
+## Overview
+
+Netdata has an incredibly powerful alerting engine that offers immense flexibility to build specific, intelligent alerts. However, mastering its syntax can feel like learning a new language.
+
+To ensure accessibility for every member on your engineering team, we created the AI-Powered Alert Configuration feature. A bridge between your intent and Netdata's syntax, letting you describe conditions in plain English while the AI handles the rest.
+
+## Capabilities
+
+### Creating production-ready alerts
+
+All you have to do to create production-ready alerts, is to simply describe your goal in plain English. For example, if you want to get ahead of a disk filling up:
+
+**"Create an alert that warns me when a disk will be more than 85% full in the next 24 hours, and goes critical if it will be more than 95% full."**
+
+Netdata AI translates your request into a perfectly formatted, syntactically correct alert definition and presents it for your review.
+
+### Suggest what to alert on
+
+You can ask Netdata AI for intelligent suggestions based on the context of your infrastructure.
+
+Netdata AI will suggest what would be a suitable alert for a specific use-case or context.
+
+### Explain what every alert does
+
+Netdata ships with hundreds of pre-configured alerts. To get masterfull insights of their underlying logic:
+
+Click on any alert definition and ask Netdata AI to **Explain** this alert. It will break down the entire definition line by line.
+
+## AI credits consumption
+
+Just like other Netdata AI functionality, usage is based on AI credits. You get 10 monthly complementary credits with a Business subscription, and you can top up credits yourself based on your needs. You also get 10 free credits on the free trial to experiment with.
+
+- **Alert creation**: 0.2 credits per run (create up to 5 alerts per AI credit)
+- **Alert suggestion**: 0.2 credits per run (up to 5 suggestions per AI credit)
+- **Alert explanation**: Free to use
+
+:::info
+
+Track your AI credit usage from `Settings → Usage & Billing → AI Credits`.
+
+:::
+
+## How to access
+
+You'll find these new AI capabilities directly within the alert configuration workflow in Netdata Cloud.
+
+### From any chart
+
+**Step 1:** Click on the **alert bell icon** (locate it by navigating your cursor on any chart)
+**Step 2:** Click on **+ Add alert**
+**Step 3:** Describe the alert you want to create
+
+You can now seamlessly:
+- Create alerts using natural language
+- Get AI suggestions for what to monitor
+- Explain existing alerts
+
+### From the Alerts tab
+
+Click on **"New Alert"** from the alerts tab to access the AI-powered alert creation workflow.
+
+### Alternative: Manual configuration
+
+You always have the option to use the manual dynamic configuration alert wizard, which gives you full control over every parameter.
+
+## Requirements
+
+- **Subscription:** Business plan or Free Trial
+- **Access:** Netdata Cloud account with appropriate permissions
+
+## Availability
+
+This feature is available today for all users on a Business plan or a free trial.
+
+## See also
+
+- [Alert Troubleshooting](/docs/troubleshooting/troubleshoot.md) - AI-powered alert investigation
+- [Netdata AI Overview](/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md) - Complete AI capabilities guide
+
+
+By letting Netdata AI handle the syntactic complexity, we're lowering the barrier to entry for effective alerting and freeing up your team to focus on what matters: building reliable, high-performance systems.
+
+:::note
+
+Despite our best efforts to eliminate inaccuracies, AI responses may sometimes be incorrect. Please review generated configurations before deploying to production systems.
+
+:::

--- a/docs/learn/unclaim-reclaim-node.md
+++ b/docs/learn/unclaim-reclaim-node.md
@@ -1,0 +1,121 @@
+# Unclaiming and Reclaiming a Node
+
+:::note
+
+**What's the difference between unclaiming/reclaiming and removing a node?**
+
+| Action | What it does | Agent status |
+|--------|--------------|--------------|
+| **Unclaim & Reclaim** | Disconnect from current Space, connect to a new Space | Agent keeps running |
+| **Remove** | Permanently delete node from Netdata Cloud | Agent may keep running but disconnected |
+
+If you want to **move a node to a different Space**, use the **unclaim and reclaim** process on this page.
+
+If you want to **permanently remove a node** from Netdata Cloud entirely, see our guide: [Removing a node from your Netdata Cloud Space](/docs/learn/remove-node.md)
+
+:::
+
+This guide covers two scenarios:
+
+1. **Unclaiming** - Disconnect a node from your current Space (keeps agent running)
+2. **Reclaiming** - Connect an unclaimed node to a new Space
+
+Use this process when you need to move a node from one Space to another without disrupting the agent's operation.
+
+## Prerequisites
+
+- The node must have Netdata Agent installed
+- You need the claiming token and room keys for the **new** Space
+- Optionally: access to the node via SSH or terminal
+
+## Unclaim a Node from Current Space
+
+### Linux-based Installations
+
+1. SSH into the node or access its terminal
+
+2. Remove the Cloud connection directory:
+
+   ```bash
+   sudo rm -rf /var/lib/netdata/cloud.d/
+   ```
+
+3. Verify the node no longer appears in your Space
+
+### Docker-based Installations
+
+1. Enter the running container:
+
+   ```bash
+   docker exec -it CONTAINER_NAME sh
+   ```
+
+2. Remove the connection files:
+
+   ```bash
+   rm -rf /var/lib/netdata/cloud.d/
+   rm /var/lib/netdata/registry/netdata.public.unique.id
+   ```
+
+3. Exit the container and recreate it with the new claim token
+
+## Reclaim to a New Space
+
+### Option 1: Quick Reclaim (Recommended)
+
+Run the standard claim command with your new Space's token:
+
+```bash
+bash <(curl -Ss https://my-netdata.io/kickstart.sh) --claim-token YOUR_NEW_TOKEN --claim-rooms YOUR_ROOMS --claim-url https://app.netdata.cloud
+```
+
+### Option 2: Configuration File
+
+Create `/INSTALL_PREFIX/etc/netdata/claim.conf` with:
+
+```bash
+[global]
+   url = https://app.netdata.cloud
+   token = NETDATA_CLOUD_SPACE_TOKEN
+   rooms = ROOM_KEY1,ROOM_KEY2
+```
+
+Then restart the agent or run:
+
+```bash
+netdatacli reload-claiming-state
+```
+
+### Option 3: Environment Variables
+
+For Docker/container deployments, set:
+
+```bash
+NETDATA_CLAIM_TOKEN=YOUR_NEW_TOKEN
+NETDATA_CLAIM_ROOMS=ROOM_KEY1,ROOM_KEY2
+```
+
+## Verification
+
+After reclaiming, verify the node appears in:
+
+- Your new Space in Netdata Cloud
+- The Rooms you specified
+- The node status shows as "Online"
+
+## Troubleshooting
+
+**Node doesn't appear in new Space:**
+- Verify the claim token is correct for the new Space
+- Check `/var/lib/netdata/cloud.d/` was removed before reclaiming
+- Review agent logs: `grep -i CLAIM /var/log/netdata/error.log`
+
+**Reconnection fails:**
+- Run `netdatacli aclk-state` to check connection status
+- Ensure the agent has internet access to `app.netdata.cloud`
+- Check for firewall blocking port 443
+
+## Related Documentation
+
+- [Remove a node from Netdata Cloud entirely](/docs/learn/remove-node.md) - For permanent node removal
+- [Connect Agent to Cloud](/src/claim/README.md) - Initial connection setup


### PR DESCRIPTION
## Summary

Create new documentation for moving nodes between Spaces without complete removal.

## Changes

- **New doc:**  - Guide for unclaiming and reclaiming nodes
- **Map update:**  - Register new doc under Netdata Cloud section

## What the guide covers

- Clarifies difference between unclaim/reclaim vs complete node removal
- Step-by-step unclaim process (Linux and Docker)
- Step-by-step reclaim process (multiple options)
- Cross-link to complete removal guide

## Learn status

- Learn path: 
- Placed above "Remove Agent" in the navigation